### PR TITLE
Upload the contents of the app_dir, not the dir itself

### DIFF
--- a/apcera-stager-api-contrib.gemspec
+++ b/apcera-stager-api-contrib.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
   gem.name          = "apcera-stager-api"
   gem.require_paths = ["lib"]
-  gem.version       = "0.2.5"
+  gem.version       = "0.3.0"
 
   gem.add_development_dependency 'rspec', '~> 2.6.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
The most basic no-op stager should simply be able to download,
extract, upload without modifying the app.  However, upload
currently wraps the files that were downloaded in another folder
before tarring them back up; if you had multiple stagers this
really adds up.

If the user really wants their files wrapped with a particular
folder, it is very simple to use execute_app to move everything
into a new folder.