### PR TITLE
Move Ruby 1.8.7 tests to allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ before_install:
   - gem update --system 2.1.11
 language: ruby
 rvm:
-  - "1.8.7"
   - "1.9.2"
   - "1.9.3"
   - "2.0.0"


### PR DESCRIPTION
The multiple gems we have require 1.9.0 or 1.9.2.

Left 1.8.7 in the tests for now since it would show clearly that
it is _not_ supported.