### PR TITLE
Enable injection prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 Documentation started at the 0.2.5 release.
 
+## 0.3.1 apcera-stager-api
+
+### Added
+- Added the ability to call execute and execute_app with variadic input which
+allows shell-less commands to be run, increasing security of the calls.
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Nothing.
+
+### Fixed
+- Nothing.
+
 ## 0.3.0 apcera-stager-api
 
 ### Added

--- a/apcera-stager-api-contrib.gemspec
+++ b/apcera-stager-api-contrib.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
   gem.name          = "apcera-stager-api"
   gem.require_paths = ["lib"]
-  gem.version       = "0.3.0"
+  gem.version       = "0.3.1"
 
   gem.add_development_dependency 'rspec', '~> 2.6.0'
   gem.add_development_dependency 'rake'

--- a/lib/apcera/stager/stager.rb
+++ b/lib/apcera/stager/stager.rb
@@ -56,11 +56,11 @@ module Apcera
 
     # Execute a command in the shell.
     # We don't want real commands in tests.
-    def execute(cmd)
+    def execute(*cmd)
       Bundler.with_clean_env do
-        result = system(cmd, @system_options)
+        result = system(*cmd, @system_options)
         if !result
-          raise Apcera::Error::ExecuteError.new("failed to execute: #{cmd}.\n")
+          raise Apcera::Error::ExecuteError.new("failed to execute: #{cmd.join(' ')}.\n")
         end
 
         result
@@ -71,13 +71,13 @@ module Apcera
 
     # Execute a command in the directory your package was extracted to (or where
     # you manually set @app_dir). Useful helper.
-    def execute_app(cmd)
+    def execute_app(*cmd)
       raise_app_path_error if @run_path == nil
       Bundler.with_clean_env do
         Dir.chdir(@run_path) do |run_path|
-          result = system(cmd, @system_options)
+          result = system(*cmd, @system_options)
           if !result
-            raise Apcera::Error::ExecuteError.new("failed to execute: #{cmd}.\n")
+            raise Apcera::Error::ExecuteError.new("failed to execute: #{cmd.join(' ')}.\n")
           end
 
           result


### PR DESCRIPTION
This change doesn't guarantee users will prevent any injection attack,
but by changing the method signature to accept a variable number
of inputs it allows callers to split their input as needed to call the
safer, shell-less kernel.system calls.