### PR TITLE
Fix issue with uploaded package not being wrapped properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 All notable changes to this project will be documented in this file.
 Documentation started at the 0.2.5 release.
 
+## 0.3.2 apcera-stager-api
+
+### Added
+- Nothing
+
+### Deprecated
+- Nothing.
+
+### Removed
+- Nothing.
+
+### Fixed
+- Fixed a problem with the upload routine that would prevent your files from
+being wrapped in the expected directory when having used `extract("some_dir")`.
+
 ## 0.3.1 apcera-stager-api
 
 ### Added

--- a/apcera-stager-api-contrib.gemspec
+++ b/apcera-stager-api-contrib.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {spec}/*`.split("\n")
   gem.name          = "apcera-stager-api"
   gem.require_paths = ["lib"]
-  gem.version       = "0.3.1"
+  gem.version       = "0.3.2"
 
   gem.add_development_dependency 'rspec', '~> 2.6.0'
   gem.add_development_dependency 'rake'

--- a/apcera-stager-api-contrib.gemspec
+++ b/apcera-stager-api-contrib.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = "0.3.2"
 
   gem.add_development_dependency 'rspec', '~> 2.6.0'
-  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'rake', '~> 10.5'
   gem.add_development_dependency 'webmock', '1.11'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'vcr'

--- a/lib/apcera/stager/stager.rb
+++ b/lib/apcera/stager/stager.rb
@@ -115,7 +115,10 @@ module Apcera
 
         upload_file(@pkg_path)
       else
-        execute_app("tar czf #{@updated_pkg_path} ./*")
+        # Use execute instead of execute_app so that if the user provided a dir
+        # to extract into it results in the uploaded package being wrapped in
+        # that directory.
+        execute("cd #{@app_path} && tar czf #{@updated_pkg_path} ./*")
 
         upload_file(@updated_pkg_path)
       end

--- a/spec/apcera/stager/stager_spec.rb
+++ b/spec/apcera/stager/stager_spec.rb
@@ -209,9 +209,33 @@ describe Apcera::Stager do
 
         @stager.extract(@appdir)
 
-        @stager.should_receive(:execute_app).with("tar czf #{@stager.updated_pkg_path} ./*").and_return
+        @stager.should_receive(:execute).with("cd #{@stager.app_path} && tar czf #{@stager.updated_pkg_path} ./*").and_return
 
         @stager.upload
+      end
+
+      it "should upload files with a wrapping directory if extracted into one" do
+        VCR.use_cassette('download') do
+          @stager.download
+        end
+
+        @stager.extract(@appdir)
+        @stager.upload
+
+        out = `tar -tf #{@stager.updated_pkg_path}`
+        out.should include("./#{@appdir}/")
+      end
+
+      it "should upload files without a wrapping directory if not extracted into one" do
+        VCR.use_cassette('download') do
+          @stager.download
+        end
+
+        @stager.extract()
+        @stager.upload
+
+        out = `tar -tf #{@stager.updated_pkg_path}`
+        out.should_not include("./#{@appdir}/")
       end
 
       it "should upload the original package when the app wasn't extracted" do

--- a/spec/fixtures/cassettes/complete.yml
+++ b/spec/fixtures/cassettes/complete.yml
@@ -52,4 +52,47 @@ http_interactions:
       string: OK
     http_version: 
   recorded_at: Mon, 25 Aug 2014 02:37:56 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: http://example.com/failed
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 21 Mar 2016 19:07:01 GMT
+      Expires:
+      - Mon, 28 Mar 2016 19:07:01 GMT
+      Server:
+      - EOS (lax004/2812)
+      Content-Length:
+      - '452'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n         \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html
+        xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n\t<head>\n\t\t<title>404
+        - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script
+        type=\"text/javascript\" src=\"http://gp1.wpc.edgecastcdn.net/00222B/jtest/beacontest.js\"></script>\n\t</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 21 Mar 2016 19:07:01 GMT
+recorded_with: VCR 3.0.1

--- a/spec/fixtures/cassettes/upload.yml
+++ b/spec/fixtures/cassettes/upload.yml
@@ -52,4 +52,47 @@ http_interactions:
       string: OK
     http_version: 
   recorded_at: Mon, 25 Aug 2014 02:00:56 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: post
+    uri: http://example.com/failed
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Cache-Control:
+      - max-age=604800
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 21 Mar 2016 19:07:00 GMT
+      Expires:
+      - Mon, 28 Mar 2016 19:07:00 GMT
+      Server:
+      - EOS (lax004/2812)
+      Content-Length:
+      - '452'
+    body:
+      encoding: UTF-8
+      string: "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC
+        \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n         \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html
+        xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n\t<head>\n\t\t<title>404
+        - Not Found</title>\n\t</head>\n\t<body>\n\t\t<h1>404 - Not Found</h1>\n\t\t<script
+        type=\"text/javascript\" src=\"http://gp1.wpc.edgecastcdn.net/00222B/jtest/beacontest.js\"></script>\n\t</body>\n</html>\n"
+    http_version: 
+  recorded_at: Mon, 21 Mar 2016 19:07:00 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
Previous 0.3.0 change failed to catch problem with upload routine
if user had extracted into a subdirectory.  This resulted in the
files in the "execution" directory being uploaded, not in the
app dir.  The only time that is different is when the user runs
`extract("some_dir")`